### PR TITLE
Allow report generation without running a scan

### DIFF
--- a/BuildTask/OwaspZapScan/owaspzapscan.ts
+++ b/BuildTask/OwaspZapScan/owaspzapscan.ts
@@ -103,7 +103,7 @@ async function run(): Promise<string> {
             }
 
             /* If all scans are successful: 1). Generate the Report 2). Perform the Verifications */
-            if (scanStatus.Success) {
+            if (scanStatus.Success || selectedScans.length === 0) {
 
                 /* Generate the report */
                 console.log('Generating the report...');


### PR DESCRIPTION
Currently you have to have at least 1 successful scan to generate a report. Since the scan results are saved on the Zap URL, you technically do not need to re-scan the app if you want to generate multiple reports. In my use case I need to output a user-friendly HTML report, but also a parsable JSON report (implemented in another PR) for another batch job to run analytics on.

This PR will enable users to run the Zap task without scanning a URL and still generate a report.